### PR TITLE
update swagger doc

### DIFF
--- a/core/base/apiServer.go
+++ b/core/base/apiServer.go
@@ -1428,7 +1428,7 @@ func handleListAllObjects(orgID string, objectType string, writer http.ResponseW
 //   type: boolean
 // - name: service
 //   in: query
-//   description: The ID of the service (orgID/architecture/version/serviceName) to which objects have affinity,
+//   description: The ID of the service (orgID/serviceName) to which objects have affinity,
 //        whose Destination Policy should be fetched.
 //   required: false
 //   type: string


### PR DESCRIPTION
Update swagger page doc for API: `/api/v1/objects/{{org}}?destination_policy=true&service=serviceOrg/serviceName`

service param should be specified as `orgID/serviceName`, instead of `orgID/arch/version/serviceName`
