### PR TITLE
Issue 91 - CSS Optimization

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -8,9 +8,11 @@ import (
 	"hash"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
+	"golang.org/x/sync/semaphore"
 )
 
 // SyncServiceError is a common error type used in the sync service
@@ -774,6 +776,16 @@ func NewLocks(name string) *Locks {
 
 	locks.locks = make([]sync.RWMutex, locks.numberOfLocks)
 	return &locks
+}
+
+
+// ObjectDownloadSemaphore sets the concurrent spi object download concurrency
+var ObjectDownloadSemaphore *semaphore.Weighted
+
+// InitObjectDownloadSemaphore initializes ObjectDownloadSemaphore
+func InitObjectDownloadSemaphore() {
+	maxWorkers := runtime.GOMAXPROCS(-1) * Configuration.HTTPCSSObjDownloadConcurrencyMultiplier
+	ObjectDownloadSemaphore = semaphore.NewWeighted(int64(maxWorkers))
 }
 
 // ObjectLocks are locks for object and notification changes

--- a/common/config.go
+++ b/common/config.go
@@ -204,6 +204,14 @@ type Config struct {
 	// default is 120s
 	HTTPESSClientTimeout int `env:"HTTPESSClientTimeout"`
 
+	// HTTPESSObjClientTimeout is to specify the http client timeout for downloading models (or objects) in seconds for ESS
+	// default is 600s
+	HTTPESSObjClientTimeout int `env:"HTTPESSObjClientTimeout"`
+
+	// HTTPCSSObjDownloadConcurrencyMultiplier specifies a number to multiple the number of threads by to set allowed concurrent downloads per CSS
+	// default is 1
+	HTTPCSSObjDownloadConcurrencyMultiplier int `env:"HTTPCSSObjDownloadConcurrencyMultiplier"`
+
 	// LogLevel specifies the logging level in string format
 	LogLevel string `env:"LOG_LEVEL"`
 
@@ -733,6 +741,8 @@ func SetDefaultConfig(config *Config) {
 	config.HTTPCSSUseSSL = false
 	config.HTTPCSSCACertificate = ""
 	config.HTTPESSClientTimeout = 120
+	config.HTTPESSObjClientTimeout = 600
+	config.HTTPCSSObjDownloadConcurrencyMultiplier = 1
 	config.MessagingGroupCacheExpiration = 60
 	config.ShutdownQuiesceTime = 60
 	config.ESSConsumedObjectsKept = 1000

--- a/core/base/apiModule_test.go
+++ b/core/base/apiModule_test.go
@@ -109,6 +109,7 @@ func testObjectAPI(store storage.Storage, t *testing.T) {
 	dataVerifier.Store = store
 
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	dests := []string{"device:dev1", "device2:dev", "device2:dev1"}
 
@@ -807,6 +808,7 @@ func testESSObjectDeletedAPI(store storage.Storage, t *testing.T) {
 	communications.Store = store
 	dataVerifier.Store = store
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	if err := store.Init(); err != nil {
 		t.Errorf("Failed to initialize storage driver. Error: %s\n", err.Error())
@@ -902,6 +904,7 @@ func TestObjectDestinationsAPI(t *testing.T) {
 func testObjectDestinationsAPI(store storage.Storage, t *testing.T) {
 	communications.Store = store
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	if err := store.Init(); err != nil {
 		t.Errorf("Failed to initialize storage driver. Error: %s\n", err.Error())
@@ -1330,6 +1333,7 @@ func testObjectWithPolicyAPI(store storage.Storage, t *testing.T) {
 
 	communications.Store = store
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	if err := store.Init(); err != nil {
 		t.Errorf("Failed to initialize storage driver. Error: %s\n", err.Error())
@@ -1414,6 +1418,7 @@ func testObjectWithPolicyAPI(store storage.Storage, t *testing.T) {
 	}
 
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	for _, destination := range destinations {
 		if err := store.StoreDestination(destination); err != nil {

--- a/core/base/apiServer_test.go
+++ b/core/base/apiServer_test.go
@@ -1403,6 +1403,7 @@ func testAPIServerSetup(nodeType string, storageType string) string {
 	}
 
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	security.SetAuthentication(&security.TestAuthenticate{})
 	security.Store = store

--- a/core/base/base.go
+++ b/core/base/base.go
@@ -145,14 +145,12 @@ func Start(swaggerFile string, registerHandlers bool) common.SyncServiceError {
 
 	if common.Configuration.NodeType == common.ESS {
 		common.Registered = false
-		if common.Configuration.CommunicationProtocol == common.HTTPProtocol {
-			go communication.Register()
-		}
 	}
 
 	common.ResendAcked = true
 
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	// storage, lock should be setup before initialize objectQueue
 	queueBufferSize := common.Configuration.ObjectQueueBufferSize

--- a/core/communications/httpCommunication.go
+++ b/core/communications/httpCommunication.go
@@ -33,11 +33,13 @@ var unauthorizedBytes = []byte("Unauthorized")
 
 // HTTP is the struct for the HTTP communications layer
 type HTTP struct {
-	httpClient          http.Client
-	started             bool
-	httpPollTimer       *time.Timer
-	httpPollStopChannel chan int
-	requestWrapper      *httpRequestWrapper
+	httpClient                http.Client
+	httpObjectDownloadClient  http.Client
+	started                   bool
+	httpPollTimer             *time.Timer
+	httpPollStopChannel       chan int
+	requestWrapper            *httpRequestWrapper
+	objDownloadRequestWrapper *httpRequestWrapper
 }
 
 type updateMessage struct {
@@ -60,6 +62,10 @@ func (communication *HTTP) StartCommunication() common.SyncServiceError {
 		http.Handle(pingURL, http.StripPrefix(pingURL, http.HandlerFunc(communication.handlePing)))
 		http.Handle(objectRequestURL, http.StripPrefix(objectRequestURL, http.HandlerFunc(communication.handleObjects)))
 	} else {
+		communication.httpObjectDownloadClient = http.Client{
+			Transport: &http.Transport{},
+			Timeout:   time.Second * time.Duration(common.Configuration.HTTPESSObjClientTimeout),
+		}
 		communication.httpClient = http.Client{
 			Transport: &http.Transport{},
 			Timeout:   time.Second * time.Duration(common.Configuration.HTTPESSClientTimeout),
@@ -85,9 +91,11 @@ func (communication *HTTP) StartCommunication() common.SyncServiceError {
 			caCertPool.AppendCertsFromPEM(certificate)
 			tlsConfig := &tls.Config{RootCAs: caCertPool}
 			communication.httpClient.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+			communication.httpObjectDownloadClient.Transport = &http.Transport{TLSClientConfig: tlsConfig}
 		}
 		communication.httpPollStopChannel = make(chan int, 1)
 		communication.requestWrapper = newHTTPRequestWrapper(communication.httpClient)
+		communication.objDownloadRequestWrapper = newHTTPRequestWrapper(communication.httpObjectDownloadClient)
 	}
 	communication.started = true
 
@@ -136,14 +144,15 @@ func (communication *HTTP) StopCommunication() common.SyncServiceError {
 	}
 
 	communication.requestWrapper.cancel()
+	communication.objDownloadRequestWrapper.cancel()
 
 	return nil
 }
 
 // HandleRegAck handles a registration acknowledgement message from the CSS
 func (communication *HTTP) HandleRegAck() {
-	if trace.IsLogging(logger.TRACE) {
-		trace.Trace("Received regack")
+	if trace.IsLogging(logger.DEBUG) {
+		trace.Debug("Received regack")
 	}
 	communication.startPolling()
 }
@@ -676,7 +685,7 @@ func (communication *HTTP) GetData(metaData common.MetaData, offset int64) commo
 	security.AddIdentityToSPIRequest(request, url)
 	request.Close = true
 
-	response, err := communication.requestWrapper.do(request)
+	response, err := communication.objDownloadRequestWrapper.do(request)
 	if response != nil && response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -792,8 +801,8 @@ func (communication *HTTP) Poll() bool {
 	}
 
 	if response.StatusCode == http.StatusNoContent {
-		if trace.IsLogging(logger.TRACE) {
-			trace.Trace("Polled the CSS, received 0 objects.\n")
+		if trace.IsLogging(logger.DEBUG) {
+			trace.Debug("Polled the CSS, received 0 objects.\n")
 		}
 		return false
 	}
@@ -814,8 +823,8 @@ func (communication *HTTP) Poll() bool {
 		return false
 	}
 
-	if trace.IsLogging(logger.TRACE) {
-		trace.Trace("Polled the CSS, received %d objects.\n", len(payload))
+	if trace.IsLogging(logger.DEBUG) {
+		trace.Debug("Polled the CSS, received %d objects.\n", len(payload))
 	}
 
 	for _, message := range payload {
@@ -1113,19 +1122,38 @@ func (communication *HTTP) handleGetData(orgID string, objectType string, object
 	if trace.IsLogging(logger.TRACE) {
 		trace.Trace("Handling object get data of %s %s %s %s \n", objectType, objectID, destType, destID)
 	}
+
+	handleGetData_enter_time := time.Now().Unix()
+
+	if common.ObjectDownloadSemaphore.TryAcquire(1) == false {
+		// If too many downloads are in flight, agent will get error and retry. Originally, there was a lock around the download that
+		// caused the downloads to be serial. It was changed to use a semaphore to allow limited concurrency.
+		if trace.IsLogging(logger.TRACE) {
+			trace.Trace("Failed to acquire semaphore for handleGetData of %s %s %s %s \n", objectType, objectID, destType, destID)
+		}
+		err := &Error{"Error in handleGetData: Unable to acquire object semaphore."}
+		SendErrorResponse(writer, err, "", http.StatusTooManyRequests)
+		return
+	}
+
+	defer common.ObjectDownloadSemaphore.Release(1)
+
 	lockIndex := common.HashStrings(orgID, objectType, objectID)
 	common.ObjectLocks.Lock(lockIndex)
-	defer common.ObjectLocks.Unlock(lockIndex)
 
 	if trace.IsLogging(logger.DEBUG) {
 		trace.Trace("Handling object get data, retrieve notification record for %s %s %s %s %s\n", orgID, objectType, objectID, destType, destID)
 	}
 	notification, err := Store.RetrieveNotificationRecord(orgID, objectType, objectID, destType, destID)
+	common.ObjectLocks.Unlock(lockIndex)
+
 	if err != nil {
 		SendErrorResponse(writer, err, "", 0)
+		return
 	} else if notification == nil {
 		err = &Error{"Error in handleGetData: no notification to update."}
 		SendErrorResponse(writer, err, "", 0)
+		return
 	} else if notification.InstanceID != instanceID {
 		if log.IsLogging(logger.ERROR) {
 			log.Error("Handling object get data, notification.InstanceID(%d) != metaData,InstanceID(%d), notification status(%s) for %s %s %s %s %s\n", notification.InstanceID, instanceID, notification.Status, orgID, objectType, objectID, destType, destID)
@@ -1133,6 +1161,7 @@ func (communication *HTTP) handleGetData(orgID string, objectType string, object
 
 		err = &ignoredByHandler{"Error in handleGetData: notification.InstanceID != instanceID or notification status is not updated."}
 		SendErrorResponse(writer, err, "", 0)
+		return
 	} else if notification.Status == common.Updated || notification.Status == common.Update || notification.Status == common.UpdatePending {
 		//  notification.InstanceID == instanceID
 		updateNotificationRecord = true
@@ -1158,36 +1187,31 @@ func (communication *HTTP) handleGetData(orgID string, objectType string, object
 		} else {
 			writer.Header().Add("Content-Type", "application/octet-stream")
 			writer.WriteHeader(http.StatusOK)
+
+			hasError := false
+
+			// Start the download
 			if _, err := io.Copy(writer, dataReader); err != nil {
+				hasError = true
 				SendErrorResponse(writer, err, "", 0)
 			}
 			if err := Store.CloseDataReader(dataReader); err != nil {
+				hasError = true
 				SendErrorResponse(writer, err, "", 0)
 			}
-			if trace.IsLogging(logger.DEBUG) {
-				trace.Debug("Handling object get data, update notification for %s %s %s %s, status: %s\n", objectType, objectID, destType, destID, common.Data)
+
+			if hasError == false && trace.IsLogging(logger.DEBUG) {
+				handleGetData_download_complete_time := time.Now().Unix()
+				trace.Debug("handleGetData has taken %d seconds to download %s %s %s %s", (handleGetData_download_complete_time - handleGetData_enter_time), orgID, objectType, objectID, destID)
 			}
-			// update notification only if current notification.InstanceID == metadata.InstanceID && current notification.status == "updated"
-			if updateNotificationRecord {
-				if trace.IsLogging(logger.DEBUG) {
-					trace.Debug("Handling object get data, update notification status to data for %s %s %s %s %s\n", orgID, objectType, objectID, destType, destID)
-				}
-				notification := common.Notification{ObjectID: objectID, ObjectType: objectType,
-					DestOrgID: orgID, DestID: destID, DestType: destType, Status: common.Data, InstanceID: instanceID, DataID: dataID}
-				if err = Store.UpdateNotificationRecord(notification); err != nil {
-					if log.IsLogging(logger.ERROR) {
-						log.Error("Handling object get data, failed to update notification for %s %s %s %s with status: %s\n", objectType, objectID, destType, destID, common.Data)
-					}
-				} else {
-					if trace.IsLogging(logger.DEBUG) {
-						log.Debug("Handling object get data, update notification for %s %s %s %s with status %s is done\n", objectType, objectID, destType, destID, common.Data)
-					}
-				}
-			} else {
-				if trace.IsLogging(logger.DEBUG) {
-					trace.Debug("Handling object get data, return without update notification status to data for %s %s %s %s %s, set updateNotificationRecord to %t \n", orgID, objectType, objectID, destType, destID, updateNotificationRecord)
-				}
-			}
+
+			/**
+			 Removed the code with the CSS setting notificationRecord to status: common.Data since with the introduction of the semaphore and a client timeout
+			 there are more possibilities of the agent receiving an error due to timeout but the CSS thinks everything completed. If the agent set the status to
+			 an error but then the CSS set the status to common.Data, the agent would not receive the model update. The only way to guarantee that the CSS would
+			 not overwrite the status from the agent was to eliminate the CSS setting the status at all.
+			**/
+
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Doug Larson <larsond@us.ibm.com>

- Use a different httpClient object for agent with a longer timeout for object download requests
- Implement a semaphore on handleGetData instead of a lock to allow some concurrent model downloads but not unlimited
- Change so that if an error occurs in the model download, don't allow the CSS to set the notification record