### PR TITLE
Issue 2543 & Issue 91

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -204,6 +204,14 @@ type Config struct {
 	// default is 120s
 	HTTPESSClientTimeout int `env:"HTTPESSClientTimeout"`
 
+	// HTTPESSObjClientTimeout is to specify the http client timeout for downloading models (or objects) in seconds for ESS
+	// default is 600s
+	HTTPESSObjClientTimeout int `env:"HTTPESSObjClientTimeout"`
+
+	// HTTPCSSObjDownloadConcurrencyMultiplier specifies a number to multiple the number of threads by to set allowed concurrent downloads per CSS
+	// default is 1
+	HTTPCSSObjDownloadConcurrencyMultiplier int `env:"HTTPCSSObjDownloadConcurrencyMultiplier"`
+
 	// LogLevel specifies the logging level in string format
 	LogLevel string `env:"LOG_LEVEL"`
 
@@ -256,6 +264,10 @@ type Config struct {
 	// CSS only parameter, ignored on ESS
 	// A value of zero means ESSs are never removed
 	RemoveESSRegistrationTime int16 `env:"REMOVE_ESS_REGISTRATION_TIME"`
+
+	// EnableDataChunk specifies whether or not to transfer data in chunks between CSS and ESS
+	// It is always true for MQTT
+	EnableDataChunk bool `env:"ENABLE_DATA_CHUNK"`
 
 	// Maximum size of data that can be sent in one message
 	MaxDataChunkSize int `env:"MAX_DATA_CHUNK_SIZE"`
@@ -493,6 +505,7 @@ func ValidateConfig() error {
 		}
 		if mqtt {
 			Configuration.CommunicationProtocol = MQTTProtocol
+			Configuration.EnableDataChunk = true
 		} else if wiotp {
 			Configuration.CommunicationProtocol = WIoTP
 		} else {
@@ -505,6 +518,7 @@ func ValidateConfig() error {
 		if http {
 			if mqtt {
 				Configuration.CommunicationProtocol = HybridMQTT
+				Configuration.EnableDataChunk = true
 			} else if wiotp {
 				Configuration.CommunicationProtocol = HybridWIoTP
 			} else {
@@ -513,6 +527,7 @@ func ValidateConfig() error {
 		} else {
 			if mqtt {
 				Configuration.CommunicationProtocol = MQTTProtocol
+				Configuration.EnableDataChunk = true
 			} else if wiotp {
 				Configuration.CommunicationProtocol = WIoTP
 			}
@@ -713,7 +728,8 @@ func SetDefaultConfig(config *Config) {
 	config.ESSCallSPIRetryInterval = 2
 	config.ESSPingInterval = 1
 	config.RemoveESSRegistrationTime = 30
-	config.MaxDataChunkSize = 120 * 1024
+	config.EnableDataChunk = true
+	config.MaxDataChunkSize = 5120 * 1024
 	config.MaxInflightChunks = 1
 	config.MongoAddressCsv = "localhost:27017"
 	config.MongoDbName = "d_edge"
@@ -733,6 +749,8 @@ func SetDefaultConfig(config *Config) {
 	config.HTTPCSSUseSSL = false
 	config.HTTPCSSCACertificate = ""
 	config.HTTPESSClientTimeout = 120
+	config.HTTPESSObjClientTimeout = 600
+	config.HTTPCSSObjDownloadConcurrencyMultiplier = 1
 	config.MessagingGroupCacheExpiration = 60
 	config.ShutdownQuiesceTime = 60
 	config.ESSConsumedObjectsKept = 1000

--- a/core/base/apiServer_test.go
+++ b/core/base/apiServer_test.go
@@ -1403,6 +1403,7 @@ func testAPIServerSetup(nodeType string, storageType string) string {
 	}
 
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	security.SetAuthentication(&security.TestAuthenticate{})
 	security.Store = store

--- a/core/base/base.go
+++ b/core/base/base.go
@@ -145,14 +145,12 @@ func Start(swaggerFile string, registerHandlers bool) common.SyncServiceError {
 
 	if common.Configuration.NodeType == common.ESS {
 		common.Registered = false
-		if common.Configuration.CommunicationProtocol == common.HTTPProtocol {
-			go communication.Register()
-		}
 	}
 
 	common.ResendAcked = true
 
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	// storage, lock should be setup before initialize objectQueue
 	queueBufferSize := common.Configuration.ObjectQueueBufferSize

--- a/core/communications/communicationWrapper.go
+++ b/core/communications/communicationWrapper.go
@@ -171,6 +171,15 @@ func (communication *Wrapper) GetData(metaData common.MetaData, offset int64) co
 	return comm.GetData(metaData, offset)
 }
 
+// PushData uploade data to from ESS to CSS
+func (communication *Wrapper) PushData(metaData *common.MetaData, offset int64) common.SyncServiceError {
+	comm, err := communication.selectCommunicator("", metaData.DestOrgID, metaData.OriginType, metaData.OriginID)
+	if err != nil {
+		return err
+	}
+	return comm.PushData(metaData, offset)
+}
+
 // SendData sends data from the CSS to the ESS or from the ESS to the CSS
 func (communication *Wrapper) SendData(orgID string, destType string, destID string, message []byte, chunked bool) common.SyncServiceError {
 	comm, err := communication.selectCommunicator("", orgID, destType, destID)

--- a/core/communications/mqttCommunication.go
+++ b/core/communications/mqttCommunication.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/eclipse/paho.mqtt.golang/packets"
 	"github.com/open-horizon/edge-sync-service/common"
 	"github.com/open-horizon/edge-sync-service/core/leader"
@@ -1134,8 +1134,16 @@ func (communication *MQTT) GetData(metaData common.MetaData, offset int64) commo
 		messageJSON, false); err != nil {
 		return err
 	}
+	lockIndex := common.HashStrings(metaData.DestOrgID, metaData.ObjectType, metaData.ObjectID)
+	common.ObjectLocks.Lock(lockIndex)
 	err = updateGetDataNotification(metaData, metaData.OriginType, metaData.OriginID, offset)
+	common.ObjectLocks.Unlock(lockIndex)
 	return err
+}
+
+// PushData uploade data to from ESS to CSS
+func (communication *MQTT) PushData(metaData *common.MetaData, offset int64) common.SyncServiceError {
+	return nil
 }
 
 // SendData sends data from the CSS to the ESS or from the ESS to the CSS

--- a/core/communications/notificationHandler_test.go
+++ b/core/communications/notificationHandler_test.go
@@ -12,6 +12,7 @@ import (
 func TestNotificationHandler(t *testing.T) {
 
 	common.InitObjectLocks()
+	common.InitObjectDownloadSemaphore()
 
 	if common.Registered {
 		t.Errorf("Registered flag is true")
@@ -41,6 +42,8 @@ func TestNotificationHandler(t *testing.T) {
 	if err := Comm.StartCommunication(); err != nil {
 		t.Errorf("Failed to start communication. Error: %s", err.Error())
 	}
+
+	common.Configuration.CommunicationProtocol = common.MQTTProtocol
 
 	common.Configuration.NodeType = common.CSS
 
@@ -235,7 +238,7 @@ func TestNotificationHandler(t *testing.T) {
 				t.Errorf("Wrong status: %s instead of completely received (objectID = %s)", storedStatus, row.metaData.ObjectID)
 			}
 			// Check data
-			storedDataReader, err := Store.RetrieveObjectData(row.metaData.DestOrgID, row.metaData.ObjectType, row.metaData.ObjectID)
+			storedDataReader, err := Store.RetrieveObjectData(row.metaData.DestOrgID, row.metaData.ObjectType, row.metaData.ObjectID, false)
 			if err != nil {
 				t.Errorf("Failed to fetch object's data (objectID = %s). Error: %s", row.metaData.ObjectID, err.Error())
 			} else {
@@ -304,7 +307,7 @@ func TestNotificationHandler(t *testing.T) {
 		}
 
 		// There should be no data
-		dataReader, _ := Store.RetrieveObjectData(row.metaData.DestOrgID, row.metaData.ObjectType, row.metaData.ObjectID)
+		dataReader, _ := Store.RetrieveObjectData(row.metaData.DestOrgID, row.metaData.ObjectType, row.metaData.ObjectID, false)
 		if dataReader != nil {
 			t.Errorf("Deleted object has data (objectID = %s)", row.metaData.ObjectID)
 		}

--- a/core/communications/testCommunication.go
+++ b/core/communications/testCommunication.go
@@ -66,6 +66,12 @@ func (communication *TestComm) GetData(metaData common.MetaData, offset int64) c
 	return err
 }
 
+// PushData uploade data to from ESS to CSS
+func (communication *TestComm) PushData(metaData *common.MetaData, offset int64) common.SyncServiceError {
+	err := updatePushDataNotification(*metaData, metaData.OriginType, metaData.OriginID, offset)
+	return err
+}
+
 // SendData sends data from the CSS to the ESS or from the ESS to the CSS
 func (communication *TestComm) SendData(orgID string, destType string, destID string, message []byte, chunked bool) common.SyncServiceError {
 	return nil

--- a/core/dataURI/dataURI_test.go
+++ b/core/dataURI/dataURI_test.go
@@ -22,10 +22,10 @@ func TestDataURI(t *testing.T) {
 	}
 
 	for _, row := range tests {
-		if err := AppendData(row.uri, bytes.NewReader(row.data), row.dataLength, row.offset, 0, true, true); err != nil {
+		if _, err := AppendData(row.uri, bytes.NewReader(row.data), row.dataLength, row.offset, 0, true, true, false); err != nil {
 			t.Errorf("Failed to store in data uri. Error: %s", err.Error())
 		} else {
-			if dataReader, err := GetData(row.uri); err != nil {
+			if dataReader, err := GetData(row.uri, false); err != nil {
 				t.Errorf("Failed to read from data uri. Error: %s", err.Error())
 			} else {
 				storedData := make([]byte, 100)
@@ -56,7 +56,7 @@ func TestDataURI(t *testing.T) {
 		if written, err := StoreData(row.uri, bytes.NewReader(row.data), row.dataLength); err != nil {
 			t.Errorf("Failed to store in data uri. Error: %s", err.Error())
 		} else {
-			if dataReader, err := GetData(row.uri); err != nil {
+			if dataReader, err := GetData(row.uri, false); err != nil {
 				t.Errorf("Failed to read from data uri. Error: %s", err.Error())
 			} else {
 				if written != int64(row.dataLength) {
@@ -84,10 +84,10 @@ func TestDataURI(t *testing.T) {
 				}
 			}
 		}
-		if err = DeleteStoredData(row.uri); err != nil {
+		if err = DeleteStoredData(row.uri, false); err != nil {
 			t.Errorf("Failed to delete stored data. Error: %s", err.Error())
 		} else {
-			if dataReader, err := GetData(row.uri); err == nil && dataReader != nil {
+			if dataReader, err := GetData(row.uri, false); err == nil && dataReader != nil {
 				t.Errorf("Read from deleted data uri")
 			}
 		}
@@ -116,7 +116,7 @@ func TestDataURI(t *testing.T) {
 			isLastChunk = true
 		}
 		for i, chunk := range row.chunks {
-			if err := AppendData(row.uri, bytes.NewReader(chunk), row.lengths[i], row.offsets[i], int64(len(row.wholeData)), isFirstChunk, isLastChunk); err != nil {
+			if _, err := AppendData(row.uri, bytes.NewReader(chunk), row.lengths[i], row.offsets[i], int64(len(row.wholeData)), isFirstChunk, isLastChunk, false); err != nil {
 				t.Errorf("Failed to store in data uri. Error: %s", err.Error())
 			}
 			isFirstChunk = false
@@ -124,7 +124,7 @@ func TestDataURI(t *testing.T) {
 				isLastChunk = true
 			}
 		}
-		if dataReader, err := GetData(row.uri); err != nil {
+		if dataReader, err := GetData(row.uri, false); err != nil {
 			t.Errorf("Failed to read from data uri. Error: %s", err.Error())
 		} else {
 			storedData := make([]byte, 100)
@@ -174,7 +174,7 @@ func TestDataURI(t *testing.T) {
 			}
 		}
 
-		if err = DeleteStoredData(row.uri); err != nil {
+		if err = DeleteStoredData(row.uri, false); err != nil {
 			t.Errorf("Failed to delete %s. Error: %s", row.uri, err)
 		}
 	}

--- a/core/dataVerifier/dataVerifier.go
+++ b/core/dataVerifier/dataVerifier.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
-	"fmt"
 	"hash"
 	"io"
 
@@ -64,15 +63,15 @@ func (dataVerifier *DataVerifier) VerifyDataSignature(data io.Reader, orgID stri
 	} else {
 		dr := io.TeeReader(data, dataVerifier.dataHash)
 		if trace.IsLogging(logger.DEBUG) {
-			trace.Debug("DataVerifier - In VerifyDataSignature, verifying and storing temp data for object %s %s\n", objectType, objectID)
+			trace.Debug("DataVerifier - In VerifyDataSignature, verifying and storing data for object %s %s\n", objectType, objectID)
 		}
 
 		if destinationDataURI != "" {
-			if _, err := dataURI.StoreTempData(destinationDataURI, dr, 0); err != nil {
+			if _, err := dataURI.StoreData(destinationDataURI, dr, 0); err != nil {
 				return false, err
 			}
 		} else {
-			if exists, err := Store.StoreObjectTempData(orgID, objectType, objectID, dr); err != nil || !exists {
+			if exists, err := Store.StoreObjectData(orgID, objectType, objectID, dr); err != nil || !exists {
 				return false, err
 			}
 		}
@@ -81,71 +80,37 @@ func (dataVerifier *DataVerifier) VerifyDataSignature(data io.Reader, orgID stri
 	}
 }
 
-// StoreVerifiedData will store the data from temp data that generated during data verification. And remove temp data
-func (dataVerifier *DataVerifier) StoreVerifiedData(orgID string, objectType string, objectID string, destinationDataURI string) common.SyncServiceError {
-	if dataVerifier.writeThrough {
-		return nil
-	}
-
-	if destinationDataURI != "" {
-		if trace.IsLogging(logger.DEBUG) {
-			trace.Debug("DataVerifier - In StoreVerifiedData, store data from tmp data for object %s %s at URI %s\n", objectType, objectID, destinationDataURI)
-		}
-		// rename the {file}.tmp to {file}
-		if err := dataURI.StoreDataFromTempData(destinationDataURI); err != nil {
-			return err
-		}
+// GetTempData is to get temp data for data verification
+func (dataVerifier *DataVerifier) GetTempData(metaData common.MetaData) (io.Reader, common.SyncServiceError) {
+	var dr io.Reader
+	var err common.SyncServiceError
+	if metaData.DestinationDataURI != "" {
+		dr, err = dataURI.GetData(metaData.DestinationDataURI, true)
 	} else {
-		// 1. Retrieve temp data, 2. Store object data, 3. Remove temp data
-		if trace.IsLogging(logger.DEBUG) {
-			trace.Debug("DataVerifier - In StoreVerifiedData, retrieve temp data for object %s %s\n", objectType, objectID)
-		}
-
-		dataReader, err := Store.RetrieveTempObjectData(orgID, objectType, objectID)
-		if err != nil {
-			return &common.InvalidRequest{Message: "Failed to read temp data fro, Error: " + err.Error()}
-		} else if dataReader == nil {
-			return &common.InvalidRequest{Message: "Read empty temp data, Error: " + err.Error()}
-		}
-
-		if trace.IsLogging(logger.DEBUG) {
-			trace.Debug("DataVerifier - In StoreVerifiedData, storing data for object %s %s\n", objectType, objectID)
-		}
-
-		if exists, err := Store.StoreObjectData(orgID, objectType, objectID, dataReader); err != nil {
-			Store.CloseDataReader(dataReader)
-			return err
-		} else if !exists {
-			Store.CloseDataReader(dataReader)
-			message := fmt.Sprintf("Object metadata is not found for object %s %s %s, Error: %s\n", orgID, objectType, objectID, err.Error())
-			return &common.InternalError{Message: message}
-		}
-		Store.CloseDataReader(dataReader)
-
-		if trace.IsLogging(logger.DEBUG) {
-			trace.Debug("DataVerifier - In StoreVerifiedData, remove temp data for object %s %s\n", objectType, objectID)
-		}
-
-		if err := Store.RemoveObjectTempData(orgID, objectType, objectID); err != nil {
-			return err
-		}
+		dr, err = Store.RetrieveObjectTempData(metaData.DestOrgID, metaData.ObjectType, metaData.ObjectID)
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
 
+	return dr, nil
 }
 
 // CleanUp function is to clean up the temp file created during data verification
 func (dataVerifier *DataVerifier) RemoveTempData(orgID string, objectType string, objectID string, destinationDataURI string) common.SyncServiceError {
 	if destinationDataURI != "" {
-		tmpFilePath := destinationDataURI + ".tmp"
-		if err := dataURI.DeleteStoredData(tmpFilePath); err != nil {
+		if err := dataURI.DeleteStoredData(destinationDataURI, true); err != nil {
 			return err
 		}
 	} else if err := Store.RemoveObjectTempData(orgID, objectType, objectID); err != nil {
 		return err
 	}
 	return nil
+}
+
+func (dataVerifier *DataVerifier) RemoveUnverifiedData(metaData common.MetaData) common.SyncServiceError {
+	return storage.DeleteStoredData(Store, metaData)
 }
 
 func (dataVerifier *DataVerifier) verifyHelper(publicKeyBytes []byte, signatureBytes []byte) (bool, common.SyncServiceError) {

--- a/core/storage/boltStorage.go
+++ b/core/storage/boltStorage.go
@@ -297,7 +297,7 @@ func (store *BoltStorage) StoreObject(metaData common.MetaData, data []byte, sta
 			return nil, err
 		}
 	} else if !metaData.MetaOnly {
-		if err := dataURI.DeleteStoredData(createDataPathFromMeta(store.localDataPath, metaData)); err != nil {
+		if err := dataURI.DeleteStoredData(createDataPathFromMeta(store.localDataPath, metaData), false); err != nil {
 			return nil, err
 		}
 	}
@@ -370,8 +370,8 @@ func (store *BoltStorage) StoreObjectData(orgID string, objectType string, objec
 }
 
 func (store *BoltStorage) StoreObjectTempData(orgID string, objectType string, objectID string, dataReader io.Reader) (bool, common.SyncServiceError) {
-	tmpDataPath := createDataPathForTempData(store.localDataPath, orgID, objectType, objectID)
-	_, err := dataURI.StoreData(tmpDataPath, dataReader, 0)
+	dataPath := createDataPath(store.localDataPath, orgID, objectType, objectID)
+	_, err := dataURI.StoreTempData(dataPath, dataReader, 0)
 	if err != nil {
 		return false, err
 	}
@@ -380,8 +380,8 @@ func (store *BoltStorage) StoreObjectTempData(orgID string, objectType string, o
 }
 
 func (store *BoltStorage) RemoveObjectTempData(orgID string, objectType string, objectID string) common.SyncServiceError {
-	tmpDataPath := createDataPathForTempData(store.localDataPath, orgID, objectType, objectID)
-	if err := dataURI.DeleteStoredData(tmpDataPath); err != nil {
+	dataPath := createDataPath(store.localDataPath, orgID, objectType, objectID)
+	if err := dataURI.DeleteStoredData(dataPath, true); err != nil {
 		if common.IsNotFound(err) {
 			return nil
 		}
@@ -390,10 +390,10 @@ func (store *BoltStorage) RemoveObjectTempData(orgID string, objectType string, 
 	return nil
 }
 
-func (store *BoltStorage) RetrieveTempObjectData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
+func (store *BoltStorage) RetrieveObjectTempData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
 	var dataReader io.Reader
-	tmpDataPath := createDataPathForTempData(store.localDataPath, orgID, objectType, objectID)
-	dataReader, err := dataURI.GetData(tmpDataPath)
+	dataPath := createDataPath(store.localDataPath, orgID, objectType, objectID)
+	dataReader, err := dataURI.GetData(dataPath, true)
 	if err != nil {
 		if common.IsNotFound(err) {
 			return nil, nil
@@ -420,12 +420,12 @@ func (store *BoltStorage) RetrieveObject(orgID string, objectType string, object
 }
 
 // RetrieveObjectData returns the object data with the specified parameters
-func (store *BoltStorage) RetrieveObjectData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
+func (store *BoltStorage) RetrieveObjectData(orgID string, objectType string, objectID string, isTempData bool) (io.Reader, common.SyncServiceError) {
 	var dataReader io.Reader
 	function := func(object boltObject) common.SyncServiceError {
 		var err error
 		if object.DataPath != "" {
-			dataReader, err = dataURI.GetData(object.DataPath)
+			dataReader, err = dataURI.GetData(object.DataPath, isTempData)
 			return err
 		}
 		return nil
@@ -792,7 +792,7 @@ func (store *BoltStorage) GetObjectsToActivate() ([]common.MetaData, common.Sync
 
 // AppendObjectData appends a chunk of data to the object's data
 func (store *BoltStorage) AppendObjectData(orgID string, objectType string, objectID string, dataReader io.Reader, dataLength uint32,
-	offset int64, total int64, isFirstChunk bool, isLastChunk bool) common.SyncServiceError {
+	offset int64, total int64, isFirstChunk bool, isLastChunk bool, isTempData bool) (bool, common.SyncServiceError) {
 
 	dataPath := ""
 	function := func(object boltObject) (boltObject, common.SyncServiceError) {
@@ -807,9 +807,36 @@ func (store *BoltStorage) AppendObjectData(orgID string, objectType string, obje
 		return object, nil
 	}
 	if err := store.updateObjectHelper(orgID, objectType, objectID, function); err != nil {
-		return err
+		return isLastChunk, err
 	}
-	return dataURI.AppendData(dataPath, dataReader, dataLength, offset, total, isFirstChunk, isLastChunk)
+	return dataURI.AppendData(dataPath, dataReader, dataLength, offset, total, isFirstChunk, isLastChunk, isTempData)
+}
+
+// Handles the last data chunk
+func (store *BoltStorage) HandleObjectInfoForLastDataChunk(orgID string, objectType string, objectID string, isTempData bool, dataSize int64) (bool, common.SyncServiceError) {
+	//dataPath := createDataPath(store.localDataPath, orgID, objectType, objectID)
+	function := func(object boltObject) (boltObject, common.SyncServiceError) {
+		if object.Status == common.NotReadyToSend {
+			object.Status = common.ReadyToSend
+		}
+		if object.Status == common.NotReadyToSend || object.Status == common.ReadyToSend {
+			newID := store.getInstanceID()
+			object.Meta.InstanceID = newID
+			object.Meta.DataID = newID
+		}
+
+		//object.DataPath = dataPath
+		object.Meta.ObjectSize = dataSize
+
+		return object, nil
+	}
+	if err := store.updateObjectHelper(orgID, objectType, objectID, function); err != nil {
+		if err == notFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // UpdateObjectStatus updates an object's status
@@ -819,6 +846,15 @@ func (store *BoltStorage) UpdateObjectStatus(orgID string, objectType string, ob
 		if status == common.ConsumedByDest {
 			object.ConsumedTimestamp = time.Now()
 		}
+		return object, nil
+	}
+	return store.updateObjectHelper(orgID, objectType, objectID, function)
+}
+
+// UpdateObjectDataVerifiedStatus updates object's dataVerified field
+func (store *BoltStorage) UpdateObjectDataVerifiedStatus(orgID string, objectType string, objectID string, verified bool) common.SyncServiceError {
+	function := func(object boltObject) (boltObject, common.SyncServiceError) {
+		object.Meta.DataVerified = verified
 		return object, nil
 	}
 	return store.updateObjectHelper(orgID, objectType, objectID, function)
@@ -942,7 +978,10 @@ func (store *BoltStorage) ActivateObject(orgID string, objectType string, object
 
 // DeleteStoredObject deletes the object
 func (store *BoltStorage) DeleteStoredObject(orgID string, objectType string, objectID string) common.SyncServiceError {
-	if err := store.DeleteStoredData(orgID, objectType, objectID); err != nil {
+	if err := store.DeleteStoredData(orgID, objectType, objectID, false); err != nil {
+		return nil
+	}
+	if err := store.DeleteStoredData(orgID, objectType, objectID, true); err != nil {
 		return nil
 	}
 	id := createObjectCollectionID(orgID, objectType, objectID)
@@ -954,18 +993,25 @@ func (store *BoltStorage) DeleteStoredObject(orgID string, objectType string, ob
 }
 
 // DeleteStoredData deletes the object's data
-func (store *BoltStorage) DeleteStoredData(orgID string, objectType string, objectID string) common.SyncServiceError {
+func (store *BoltStorage) DeleteStoredData(orgID string, objectType string, objectID string, isTempData bool) common.SyncServiceError {
 	function := func(object boltObject) (boltObject, common.SyncServiceError) {
 		if object.DataPath == "" {
 			return object, nil
 		}
-		if err := dataURI.DeleteStoredData(object.DataPath); err != nil {
+		if err := dataURI.DeleteStoredData(object.DataPath, isTempData); err != nil {
 			return object, err
 		}
-		object.DataPath = ""
+		if !isTempData {
+			object.DataPath = ""
+		}
 		return object, nil
 	}
-	return store.updateObjectHelper(orgID, objectType, objectID, function)
+
+	err := store.updateObjectHelper(orgID, objectType, objectID, function)
+	if err != nil && err != notFound {
+		return err
+	}
+	return nil
 }
 
 // CleanObjects removes the objects received from the other side.

--- a/core/storage/boltStorageHelpers.go
+++ b/core/storage/boltStorageHelpers.go
@@ -96,7 +96,10 @@ func (store *BoltStorage) deleteObjectsHelper(match func(boltObject) bool) commo
 			}
 			if match(object) {
 				if object.DataPath != "" {
-					if err := dataURI.DeleteStoredData(object.DataPath); err != nil {
+					if err := dataURI.DeleteStoredData(object.DataPath, false); err != nil {
+						return err
+					}
+					if err := dataURI.DeleteStoredData(object.DataPath, true); err != nil {
 						return err
 					}
 					object.DataPath = ""
@@ -123,7 +126,10 @@ func (store *BoltStorage) deleteObjectsAndNotificationsHelper(match func(boltObj
 			}
 			if match(object) {
 				if object.DataPath != "" {
-					if err := dataURI.DeleteStoredData(object.DataPath); err != nil {
+					if err := dataURI.DeleteStoredData(object.DataPath, false); err != nil {
+						return err
+					}
+					if err := dataURI.DeleteStoredData(object.DataPath, true); err != nil {
 						return err
 					}
 					object.DataPath = ""

--- a/core/storage/cache.go
+++ b/core/storage/cache.go
@@ -80,19 +80,28 @@ func (store *Cache) RemoveObjectTempData(orgID string, objectType string, object
 	return store.Store.RemoveObjectTempData(orgID, objectType, objectID)
 }
 
-func (store *Cache) RetrieveTempObjectData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
-	return store.Store.RetrieveTempObjectData(orgID, objectType, objectID)
+func (store *Cache) RetrieveObjectTempData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
+	return store.Store.RetrieveObjectTempData(orgID, objectType, objectID)
 }
 
 // AppendObjectData appends a chunk of data to the object's data
 func (store *Cache) AppendObjectData(orgID string, objectType string, objectID string, dataReader io.Reader, dataLength uint32,
-	offset int64, total int64, isFirstChunk bool, isLastChunk bool) common.SyncServiceError {
-	return store.Store.AppendObjectData(orgID, objectType, objectID, dataReader, dataLength, offset, total, isFirstChunk, isLastChunk)
+	offset int64, total int64, isFirstChunk bool, isLastChunk bool, isTempData bool) (bool, common.SyncServiceError) {
+	return store.Store.AppendObjectData(orgID, objectType, objectID, dataReader, dataLength, offset, total, isFirstChunk, isLastChunk, isTempData)
+}
+
+func (store *Cache) HandleObjectInfoForLastDataChunk(orgID string, objectType string, objectID string, isTempData bool, dataSize int64) (bool, common.SyncServiceError) {
+	return store.Store.HandleObjectInfoForLastDataChunk(orgID, objectType, objectID, isTempData, dataSize)
 }
 
 // UpdateObjectStatus updates an object's status
 func (store *Cache) UpdateObjectStatus(orgID string, objectType string, objectID string, status string) common.SyncServiceError {
 	return store.Store.UpdateObjectStatus(orgID, objectType, objectID, status)
+}
+
+// UpdateObjectDataVerifiedStatus updates object's dataVerified field
+func (store *Cache) UpdateObjectDataVerifiedStatus(orgID string, objectType string, objectID string, verified bool) common.SyncServiceError {
+	return store.Store.UpdateObjectDataVerifiedStatus(orgID, objectType, objectID, verified)
 }
 
 // UpdateObjectSourceDataURI pdates object's source data URI
@@ -181,8 +190,8 @@ func (store *Cache) RetrieveObjectAndStatus(orgID string, objectType string, obj
 }
 
 // RetrieveObjectData returns the object data with the specified parameters
-func (store *Cache) RetrieveObjectData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
-	return store.Store.RetrieveObjectData(orgID, objectType, objectID)
+func (store *Cache) RetrieveObjectData(orgID string, objectType string, objectID string, isTempData bool) (io.Reader, common.SyncServiceError) {
+	return store.Store.RetrieveObjectData(orgID, objectType, objectID, isTempData)
 }
 
 // ReadObjectData returns the object data with the specified parameters
@@ -221,8 +230,8 @@ func (store *Cache) DeleteStoredObject(orgID string, objectType string, objectID
 }
 
 // DeleteStoredData deletes the object's data
-func (store *Cache) DeleteStoredData(orgID string, objectType string, objectID string) common.SyncServiceError {
-	return store.Store.DeleteStoredData(orgID, objectType, objectID)
+func (store *Cache) DeleteStoredData(orgID string, objectType string, objectID string, isTempData bool) common.SyncServiceError {
+	return store.Store.DeleteStoredData(orgID, objectType, objectID, isTempData)
 }
 
 // CleanObjects removes the objects received from the other side.

--- a/core/storage/inMemoryStorage.go
+++ b/core/storage/inMemoryStorage.go
@@ -196,7 +196,7 @@ func (store *InMemoryStorage) RemoveObjectTempData(orgID string, objectType stri
 	return notFound
 }
 
-func (store *InMemoryStorage) RetrieveTempObjectData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
+func (store *InMemoryStorage) RetrieveObjectTempData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
 	store.lock()
 	defer store.unLock()
 
@@ -213,7 +213,7 @@ func (store *InMemoryStorage) RetrieveTempObjectData(orgID string, objectType st
 
 // AppendObjectData appends a chunk of data to the object's data
 func (store *InMemoryStorage) AppendObjectData(orgID string, objectType string, objectID string, dataReader io.Reader, dataLength uint32,
-	offset int64, total int64, isFirstChunk bool, isLastChunk bool) common.SyncServiceError {
+	offset int64, total int64, isFirstChunk bool, isLastChunk bool, isTempData bool) (bool, common.SyncServiceError) {
 	store.lock()
 	defer store.unLock()
 
@@ -224,7 +224,7 @@ func (store *InMemoryStorage) AppendObjectData(orgID string, objectType string, 
 		if dataLength == 0 {
 			dt, err := ioutil.ReadAll(dataReader)
 			if err != nil {
-				return &Error{"Failed to read object data. Error: " + err.Error()}
+				return isLastChunk, &Error{"Failed to read object data. Error: " + err.Error()}
 			}
 			data = dt
 			dataLength = uint32(len(data))
@@ -233,26 +233,73 @@ func (store *InMemoryStorage) AppendObjectData(orgID string, objectType string, 
 			total = offset + int64(dataLength)
 		}
 		if isFirstChunk {
-			object.data = make([]byte, total)
+			if isTempData {
+				object.tmpData = make([]byte, total)
+			} else {
+				object.data = make([]byte, total)
+			}
+
 		} else {
-			object.data = ensureArrayCapacity(object.data, total)
+			if isTempData {
+				object.tmpData = ensureArrayCapacity(object.tmpData, total)
+			} else {
+				object.data = ensureArrayCapacity(object.data, total)
+			}
+
 		}
 		if data != nil {
-			copy(object.data[offset:], data)
+			if isTempData {
+				copy(object.tmpData[offset:], data)
+			} else {
+				copy(object.data[offset:], data)
+			}
+
 		} else {
-			count, err := dataReader.Read(object.data[offset:])
-			if err != nil {
-				return &Error{"Failed to read object data. Error: " + err.Error()}
+			var count int
+			var err error
+			if isTempData {
+				count, err = dataReader.Read(object.tmpData[offset:])
+			} else {
+				count, err = dataReader.Read(object.data[offset:])
+			}
+
+			if err != nil && err != io.EOF {
+				return isLastChunk, &Error{"Failed to read object data. Error: " + err.Error()}
 			}
 			if count != int(dataLength) {
-				return &Error{fmt.Sprintf("Read %d bytes for the object data, instead of %d", count, dataLength)}
+				return isLastChunk, &Error{fmt.Sprintf("Read %d bytes for the object data, instead of %d", count, dataLength)}
 			}
 		}
 		store.objects[id] = object
-		return nil
+		return isLastChunk, nil
 	}
 
-	return notFound
+	return isLastChunk, notFound
+}
+
+func (store *InMemoryStorage) HandleObjectInfoForLastDataChunk(orgID string, objectType string, objectID string, isTempData bool, dataSize int64) (bool, common.SyncServiceError) {
+	if isTempData {
+		return false, nil
+	}
+	store.lock()
+	defer store.unLock()
+
+	id := createObjectCollectionID(orgID, objectType, objectID)
+	if object, ok := store.objects[id]; ok {
+		if object.status == common.NotReadyToSend {
+			object.status = common.ReadyToSend
+		}
+		if object.status == common.NotReadyToSend || object.status == common.ReadyToSend {
+			newID := store.getInstanceID()
+			object.meta.InstanceID = newID
+			object.meta.DataID = newID
+		}
+		object.meta.ObjectSize = dataSize
+		store.objects[id] = object
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // UpdateObjectStatus updates an object's status
@@ -266,6 +313,21 @@ func (store *InMemoryStorage) UpdateObjectStatus(orgID string, objectType string
 		if status == common.ConsumedByDest {
 			object.consumedTimestamp = time.Now()
 		}
+		store.objects[id] = object
+		return nil
+	}
+
+	return &NotFound{"Object not found"}
+}
+
+// UpdateObjectDataVerifiedStatus updates object's dataVerified field
+func (store *InMemoryStorage) UpdateObjectDataVerifiedStatus(orgID string, objectType string, objectID string, verified bool) common.SyncServiceError {
+	store.lock()
+	defer store.unLock()
+
+	id := createObjectCollectionID(orgID, objectType, objectID)
+	if object, ok := store.objects[id]; ok {
+		object.meta.DataVerified = verified
 		store.objects[id] = object
 		return nil
 	}
@@ -474,14 +536,20 @@ func (store *InMemoryStorage) RetrieveObjectAndStatus(orgID string, objectType s
 }
 
 // RetrieveObjectData returns the object data with the specified parameters
-func (store *InMemoryStorage) RetrieveObjectData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
+func (store *InMemoryStorage) RetrieveObjectData(orgID string, objectType string, objectID string, isTempData bool) (io.Reader, common.SyncServiceError) {
 	store.lock()
 	defer store.unLock()
 
 	id := createObjectCollectionID(orgID, objectType, objectID)
 	if object, ok := store.objects[id]; ok {
-		if object.data != nil && len(object.data) > 0 {
-			return bytes.NewReader(object.data), nil
+		if isTempData {
+			if object.tmpData != nil && len(object.tmpData) > 0 {
+				return bytes.NewReader(object.tmpData), nil
+			}
+		} else {
+			if object.data != nil && len(object.data) > 0 {
+				return bytes.NewReader(object.data), nil
+			}
 		}
 		return nil, nil
 	}
@@ -586,18 +654,22 @@ func (store *InMemoryStorage) DeleteStoredObject(orgID string, objectType string
 }
 
 // DeleteStoredData deletes the object's data
-func (store *InMemoryStorage) DeleteStoredData(orgID string, objectType string, objectID string) common.SyncServiceError {
+func (store *InMemoryStorage) DeleteStoredData(orgID string, objectType string, objectID string, isTempData bool) common.SyncServiceError {
 	store.lock()
 	defer store.unLock()
 
 	id := createObjectCollectionID(orgID, objectType, objectID)
 	if object, ok := store.objects[id]; ok {
-		object.data = nil
+		if isTempData {
+			object.tmpData = nil
+		} else {
+			object.data = nil
+		}
 		store.objects[id] = object
 		return nil
 	}
 
-	return notFound
+	return nil
 }
 
 // CleanObjects removes the objects received from the other side.
@@ -1044,7 +1116,7 @@ func (store *InMemoryStorage) readPersistedTimebase(path string) int64 {
 		return 0
 	}
 
-	data, err := dataURI.GetData("file://" + path)
+	data, err := dataURI.GetData("file://"+path, false)
 	if err != nil || data == nil {
 		return 0
 	}

--- a/core/storage/mongoStorage.go
+++ b/core/storage/mongoStorage.go
@@ -103,6 +103,15 @@ type aclObject struct {
 	LastUpdate bson.MongoTimestamp `bson:"last-update"`
 }
 
+type dataInfoObject struct {
+	ID         string              `bson:"_id"`
+	ChunkSize  int32               `bson:"chunkSize"`
+	UploadDate bson.MongoTimestamp `bson:"uploadDate"`
+	Length     int32               `bson:"length"`
+	MD5        string              `bson:"md5"`
+	Filename   string              `bson:"filename"`
+}
+
 const maxUpdateTries = 5
 
 var sleepInMS int
@@ -980,8 +989,14 @@ func (store *MongoStorage) RetrieveObjectAndStatus(orgID string, objectType stri
 }
 
 // RetrieveObjectData returns the object data with the specified parameters
-func (store *MongoStorage) RetrieveObjectData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
-	id := createObjectCollectionID(orgID, objectType, objectID)
+func (store *MongoStorage) RetrieveObjectData(orgID string, objectType string, objectID string, isTempData bool) (io.Reader, common.SyncServiceError) {
+	var id string
+	if isTempData {
+		id = createTempObjectCollectionID(orgID, objectType, objectID)
+	} else {
+		id = createObjectCollectionID(orgID, objectType, objectID)
+	}
+
 	fileHandle, err := store.openFile(id)
 	if err != nil {
 		switch err {
@@ -1116,7 +1131,7 @@ func (store *MongoStorage) RemoveObjectTempData(orgID string, objectType string,
 
 }
 
-func (store *MongoStorage) RetrieveTempObjectData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
+func (store *MongoStorage) RetrieveObjectTempData(orgID string, objectType string, objectID string) (io.Reader, common.SyncServiceError) {
 	id := createTempObjectCollectionID(orgID, objectType, objectID)
 	fileHandle, err := store.openFile(id)
 	if err != nil {
@@ -1133,20 +1148,26 @@ func (store *MongoStorage) RetrieveTempObjectData(orgID string, objectType strin
 
 // AppendObjectData appends a chunk of data to the object's data
 func (store *MongoStorage) AppendObjectData(orgID string, objectType string, objectID string, dataReader io.Reader,
-	dataLength uint32, offset int64, total int64, isFirstChunk bool, isLastChunk bool) common.SyncServiceError {
-	id := createObjectCollectionID(orgID, objectType, objectID)
+	dataLength uint32, offset int64, total int64, isFirstChunk bool, isLastChunk bool, isTempData bool) (bool, common.SyncServiceError) {
+	var id string
+	if isTempData {
+		id = createTempObjectCollectionID(orgID, objectType, objectID)
+	} else {
+		id = createObjectCollectionID(orgID, objectType, objectID)
+	}
+
 	var fileHandle *fileHandle
 	if isFirstChunk {
 		store.removeFile(id)
 		fh, err := store.createFile(id)
 		if err != nil {
-			return err
+			return isLastChunk, err
 		}
 		fileHandle = fh
 	} else {
 		fh := store.getFileHandle(id)
 		if fh == nil {
-			return &Error{fmt.Sprintf("Failed to append the data at offset %d, the file %s doesn't exist.", offset, id)}
+			return isLastChunk, &Error{fmt.Sprintf("Failed to append the data at offset %d, the file %s doesn't exist.", offset, id)}
 		}
 		fileHandle = fh
 	}
@@ -1161,23 +1182,23 @@ func (store *MongoStorage) AppendObjectData(orgID string, objectType string, obj
 		data, err = ioutil.ReadAll(dataReader)
 		n = len(data)
 	}
-	if err != nil {
-		return &Error{fmt.Sprintf("Failed to read the data from the dataReader. Error: %s.", err)}
+	if err != nil && err != io.EOF {
+		return isLastChunk, &Error{fmt.Sprintf("Failed to read the data from the dataReader. Error: %s.", err)}
 	}
 	if uint32(n) != dataLength && dataLength > 0 {
-		return &Error{fmt.Sprintf("Failed to read all the data from the dataReader. Read %d instead of %d.", n, dataLength)}
+		return isLastChunk, &Error{fmt.Sprintf("Failed to read all the data from the dataReader. Read %d instead of %d.", n, dataLength)}
 	}
 	if offset == fileHandle.offset {
 		for {
 			if trace.IsLogging(logger.TRACE) {
-				trace.Trace(" Put data (%d) in file at offset %d\n", len(data), fileHandle.offset)
+				trace.Trace(" Put data (data size: %d) in file at offset %d\n", len(data), fileHandle.offset)
 			}
 			n, err = fileHandle.file.Write(data)
 			if err != nil {
-				return &Error{fmt.Sprintf("Failed to write the data to the file. Error: %s.", err)}
+				return isLastChunk, &Error{fmt.Sprintf("Failed to write the data to the file. Error: %s.", err)}
 			}
 			if n != len(data) {
-				return &Error{fmt.Sprintf("Failed to write all the data to the file. Wrote %d instead of %d.", n, len(data))}
+				return isLastChunk, &Error{fmt.Sprintf("Failed to write all the data to the file. Wrote %d instead of %d.", n, len(data))}
 			}
 			fileHandle.offset += int64(n)
 			if fileHandle.chunks == nil {
@@ -1200,24 +1221,79 @@ func (store *MongoStorage) AppendObjectData(orgID string, objectType string, obj
 			if trace.IsLogging(logger.INFO) {
 				trace.Info(" Discard data chunk at offset %d since there are too many (%d) out-of-order chunks\n", offset, len(fileHandle.chunks))
 			}
-			return &Discarded{fmt.Sprintf(" Discard data chunk at offset %d since there are too many out-of-order chunks\n", offset)}
+			return isLastChunk, &Discarded{fmt.Sprintf(" Discard data chunk at offset %d since there are too many out-of-order chunks\n", offset)}
 		}
 		fileHandle.chunks[offset] = data
 		if trace.IsLogging(logger.TRACE) {
 			trace.Trace(" Put data (%d) in map at offset %d (# in map %d)\n", len(data), offset, len(fileHandle.chunks))
 		}
 	}
-	if isLastChunk {
+
+	fileSize := fileHandle.file.Size()
+	if trace.IsLogging(logger.TRACE) {
+		trace.Trace(" FileSize is: %d\n", fileSize)
+	}
+
+	updatedLastChunk := isLastChunk
+	if fileSize == total {
+
+		updatedLastChunk = true
+		if trace.IsLogging(logger.TRACE) {
+			trace.Trace(" FileSize is same as total, set updatedLastChunk to %t\n", updatedLastChunk)
+		}
+	}
+
+	if updatedLastChunk {
 		store.deleteFileHandle(id)
 		err := fileHandle.file.Close()
 		if err != nil {
-			return &Error{fmt.Sprintf("Failed to close the file. Error: %s.", err)}
+			return updatedLastChunk, &Error{fmt.Sprintf("Failed to close the file. Error: %s.", err)}
 		}
 	} else {
 		store.putFileHandle(id, fileHandle)
 	}
 
-	return nil
+	return updatedLastChunk, nil
+}
+
+// Handles the last data chunk
+func (store *MongoStorage) HandleObjectInfoForLastDataChunk(orgID string, objectType string, objectID string, isTempData bool, dataSize int64) (bool, common.SyncServiceError) {
+	if isTempData {
+		return false, nil
+	}
+
+	id := createObjectCollectionID(orgID, objectType, objectID)
+
+	result := object{}
+	if err := store.fetchOne(objects, bson.M{"_id": id}, bson.M{"status": bson.ElementString}, &result); err != nil {
+		switch err {
+		case mgo.ErrNotFound:
+			return false, nil
+		default:
+			return false, &Error{fmt.Sprintf("Failed to store the data. Error: %s.", err)}
+		}
+	}
+
+	if result.Status == common.NotReadyToSend {
+		store.UpdateObjectStatus(orgID, objectType, objectID, common.ReadyToSend)
+	}
+	if result.Status == common.NotReadyToSend || result.Status == common.ReadyToSend {
+		newID := store.getInstanceID()
+		if err := store.update(objects, bson.M{"_id": id},
+			bson.M{
+				"$set":         bson.M{"metadata.data-id": newID, "metadata.instance-id": newID},
+				"$currentDate": bson.M{"last-update": bson.M{"$type": "timestamp"}},
+			}); err != nil {
+			return false, &Error{fmt.Sprintf("Failed to set instance id. Error: %s.", err)}
+		}
+	}
+
+	// Update object size
+	if err := store.update(objects, bson.M{"_id": id}, bson.M{"$set": bson.M{"metadata.object-size": dataSize}}); err != nil {
+		return false, &Error{fmt.Sprintf("Failed to update object's size. Error: %s.", err)}
+	}
+
+	return true, nil
 }
 
 // UpdateObjectStatus updates object's status
@@ -1229,6 +1305,19 @@ func (store *MongoStorage) UpdateObjectStatus(orgID string, objectType string, o
 			"$currentDate": bson.M{"last-update": bson.M{"$type": "timestamp"}},
 		}); err != nil {
 		return &Error{fmt.Sprintf("Failed to update object's status. Error: %s.", err)}
+	}
+	return nil
+}
+
+// UpdateObjectDataVerifiedStatus updates object's dataVerified field
+func (store *MongoStorage) UpdateObjectDataVerifiedStatus(orgID string, objectType string, objectID string, verified bool) common.SyncServiceError {
+	id := createObjectCollectionID(orgID, objectType, objectID)
+	if err := store.update(objects, bson.M{"_id": id},
+		bson.M{
+			"$set":         bson.M{"metadata.data-verified": verified},
+			"$currentDate": bson.M{"last-update": bson.M{"$type": "timestamp"}},
+		}); err != nil {
+		return &Error{fmt.Sprintf("Failed to update object's data-verified status. Error: %s.", err)}
 	}
 	return nil
 }
@@ -1282,8 +1371,14 @@ func (store *MongoStorage) DeleteStoredObject(orgID string, objectType string, o
 }
 
 // DeleteStoredData deletes the object's data
-func (store *MongoStorage) DeleteStoredData(orgID string, objectType string, objectID string) common.SyncServiceError {
-	id := createObjectCollectionID(orgID, objectType, objectID)
+func (store *MongoStorage) DeleteStoredData(orgID string, objectType string, objectID string, isTempData bool) common.SyncServiceError {
+	var id string
+	if isTempData {
+		id = createTempObjectCollectionID(orgID, objectType, objectID)
+	} else {
+		id = createObjectCollectionID(orgID, objectType, objectID)
+	}
+
 	if trace.IsLogging(logger.TRACE) {
 		trace.Trace("Deleting object's data %s\n", id)
 	}
@@ -1749,10 +1844,10 @@ func (store *MongoStorage) RetrieveNotifications(orgID string, destType string, 
 		if retrieveReceived {
 			query = bson.M{"$or": []bson.M{
 				bson.M{"notification.status": common.Update},
+				bson.M{"notification.status": common.Updated},
 				bson.M{"notification.status": common.Received},
 				bson.M{"notification.status": common.Consumed},
 				bson.M{"notification.status": common.Getdata},
-				bson.M{"notification.status": common.Data},
 				bson.M{"notification.status": common.ReceivedByDestination},
 				bson.M{"notification.status": common.Delete},
 				bson.M{"notification.status": common.Deleted}},
@@ -1791,6 +1886,7 @@ func (store *MongoStorage) RetrievePendingNotifications(orgID string, destType s
 	if destType == "" && destID == "" {
 		query = bson.M{"$or": []bson.M{
 			bson.M{"notification.status": common.UpdatePending},
+			bson.M{"notification.status": common.ReceivedPending},
 			bson.M{"notification.status": common.ConsumedPending},
 			bson.M{"notification.status": common.DeletePending},
 			bson.M{"notification.status": common.DeletedPending}},
@@ -1798,6 +1894,7 @@ func (store *MongoStorage) RetrievePendingNotifications(orgID string, destType s
 	} else {
 		query = bson.M{"$or": []bson.M{
 			bson.M{"notification.status": common.UpdatePending},
+			bson.M{"notification.status": common.ReceivedPending},
 			bson.M{"notification.status": common.ConsumedPending},
 			bson.M{"notification.status": common.DeletePending},
 			bson.M{"notification.status": common.DeletedPending}},

--- a/core/storage/storage_test.go
+++ b/core/storage/storage_test.go
@@ -847,7 +847,7 @@ func testStorageObjectData(storageType string, t *testing.T) {
 
 		// Check stored data
 		dataReader, err := store.RetrieveObjectData(test.metaData.DestOrgID,
-			test.metaData.ObjectType, test.metaData.ObjectID)
+			test.metaData.ObjectType, test.metaData.ObjectID, false)
 		if err != nil {
 			t.Errorf("Failed to retrieve object's data' (objectID = %s). Error: %s\n", test.metaData.ObjectID, err.Error())
 		} else if dataReader == nil {
@@ -968,11 +968,11 @@ func testStorageObjectData(storageType string, t *testing.T) {
 
 		// Append data
 		if test.data != nil {
-			if err := store.AppendObjectData(test.metaData.DestOrgID, test.metaData.ObjectType, test.metaData.ObjectID,
-				bytes.NewReader(test.data), uint32(len(test.data)), 0, test.metaData.ObjectSize, true, false); err != nil {
+			if _, err := store.AppendObjectData(test.metaData.DestOrgID, test.metaData.ObjectType, test.metaData.ObjectID,
+				bytes.NewReader(test.data), uint32(len(test.data)), 0, test.metaData.ObjectSize, true, false, false); err != nil {
 				t.Errorf("AppendObjectData failed (objectID = %s). Error: %s\n", test.metaData.ObjectID, err.Error())
-			} else if err := store.AppendObjectData(test.metaData.DestOrgID, test.metaData.ObjectType, test.metaData.ObjectID,
-				bytes.NewReader(test.newData), uint32(len(test.newData)), int64(len(test.data)), test.metaData.ObjectSize, false, true); err != nil {
+			} else if _, err := store.AppendObjectData(test.metaData.DestOrgID, test.metaData.ObjectType, test.metaData.ObjectID,
+				bytes.NewReader(test.newData), uint32(len(test.newData)), int64(len(test.data)), test.metaData.ObjectSize, false, true, false); err != nil {
 				t.Errorf("AppendObjectData failed (objectID = %s). Error: %s\n", test.metaData.ObjectID, err.Error())
 			} else {
 				expectedData := append(test.data, test.newData...)


### PR DESCRIPTION
This PR contains the code changes for both:
Issue 2543: https://github.com/open-horizon/anax/issues/2543
Issue 91: https://github.com/open-horizon/edge-sync-service/issues/91

To enable chunk data downloading and uploading between CSS and ESS over HTTP protocol. 
Also introduce Semaphore (Implemented by @dlarson04 in this original [PR](https://github.com/open-horizon/edge-sync-service/pull/92)):
- Use a different httpClient object for agent with a longer timeout for object download requests
- Implement a semaphore on handleGetData instead of a lock to allow some concurrent model downloads but not unlimited
- Change so that if an error occurs in the model download, don't allow the CSS to set the notification record

Signed-off-by: zhangl <zhangl@us.ibm.com>