### PR TITLE
fix CWE-732: Insecure File Permissions

### DIFF
--- a/core/base/http.go
+++ b/core/base/http.go
@@ -99,7 +99,7 @@ func startHTTPServer(ipAddress string, registerHandlers bool, swaggerFile string
 			if err != nil {
 				return &common.SetupError{Message: fmt.Sprintf("Failed to setup Unix Socket listening. Error: %s", err)}
 			}
-			if err := os.Chmod(socketFile, 0o644); err != nil {
+			if err := os.Chmod(socketFile, 0o666); err != nil {
 				return &common.SetupError{Message: fmt.Sprintf("Failed to setup permission for Unix Socket listening. Error: %s", err)}
 			}
 			go startHTTPServerHelper(common.Configuration.ListeningType == common.ListeningSecureUnix, listener)

--- a/core/base/http.go
+++ b/core/base/http.go
@@ -99,7 +99,7 @@ func startHTTPServer(ipAddress string, registerHandlers bool, swaggerFile string
 			if err != nil {
 				return &common.SetupError{Message: fmt.Sprintf("Failed to setup Unix Socket listening. Error: %s", err)}
 			}
-			if err := os.Chmod(socketFile, 0o655); err != nil {
+			if err := os.Chmod(socketFile, 0o644); err != nil {
 				return &common.SetupError{Message: fmt.Sprintf("Failed to setup permission for Unix Socket listening. Error: %s", err)}
 			}
 			go startHTTPServerHelper(common.Configuration.ListeningType == common.ListeningSecureUnix, listener)

--- a/core/base/http.go
+++ b/core/base/http.go
@@ -99,7 +99,7 @@ func startHTTPServer(ipAddress string, registerHandlers bool, swaggerFile string
 			if err != nil {
 				return &common.SetupError{Message: fmt.Sprintf("Failed to setup Unix Socket listening. Error: %s", err)}
 			}
-			if err := os.Chmod(socketFile, 0o777); err != nil {
+			if err := os.Chmod(socketFile, 0o655); err != nil {
 				return &common.SetupError{Message: fmt.Sprintf("Failed to setup permission for Unix Socket listening. Error: %s", err)}
 			}
 			go startHTTPServerHelper(common.Configuration.ListeningType == common.ListeningSecureUnix, listener)

--- a/core/base/http.go
+++ b/core/base/http.go
@@ -99,7 +99,7 @@ func startHTTPServer(ipAddress string, registerHandlers bool, swaggerFile string
 			if err != nil {
 				return &common.SetupError{Message: fmt.Sprintf("Failed to setup Unix Socket listening. Error: %s", err)}
 			}
-			if err := os.Chmod(socketFile, 0o666); err != nil {
+			if err := os.Chmod(socketFile, 0o660); err != nil {
 				return &common.SetupError{Message: fmt.Sprintf("Failed to setup permission for Unix Socket listening. Error: %s", err)}
 			}
 			go startHTTPServerHelper(common.Configuration.ListeningType == common.ListeningSecureUnix, listener)


### PR DESCRIPTION
When a resource is given a permissions setting that provides access to a wider range of actors than required, it could lead to the exposure of sensitive information, or the modification of that resource by unintended parties. This is especially dangerous when the resource is related to program configuration, execution or sensitive user data.
Socketfile permissions changed from 777 to 655