### PR TITLE
fix CWE-22 path/directory traversal

### DIFF
--- a/core/dataURI/dataURI.go
+++ b/core/dataURI/dataURI.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/open-horizon/edge-sync-service/common"
@@ -175,7 +176,7 @@ func GetData(uri string, isTempData bool) (io.Reader, common.SyncServiceError) {
 		trace.Trace("Retrieving data from %s", filePath)
 	}
 
-	file, err := os.Open(filePath)
+	file, err := os.Open(filepath.Clean(filePath))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, &common.NotFound{}
@@ -197,7 +198,7 @@ func GetDataChunk(uri string, size int, offset int64) ([]byte, bool, int, common
 		trace.Trace("Retrieving data from %s", uri)
 	}
 
-	file, err := os.Open(dataURI.Path)
+	file, err := os.Open(filepath.Clean(dataURI.Path))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, true, 0, &common.NotFound{}


### PR DESCRIPTION
Path/Directory Traversal or file disclosure vulnerability occurs when an external input is used to construct a pathname that is intended to identify a file or a directory located underneath a restricted parent directory. The application does not properly neutralize (sanitize) special elements within the pathname, which can cause the pathname to resolve to a location that is outside of the restricted directory. Successful file disclosure attack can result in sensitive files disclosure, and can often lead to full system compromise.